### PR TITLE
Update do Alpine v3.6

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
-ENV ALPINE_VERSION=3.5
+ENV ALPINE_VERSION=3.6
 
 # Install needed packages. Notes:
 #   * dumb-init: a proper init system for containers, to reap zombie children

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
-ENV ALPINE_VERSION=3.5
+ENV ALPINE_VERSION=3.6
 
 # These are always installed. Notes:
 #   * dumb-init: a proper init system for containers, to reap zombie children

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
-ENV ALPINE_VERSION=3.5
+ENV ALPINE_VERSION=3.6
 
 # Install needed packages. Notes:
 #   * dumb-init: a proper init system for containers, to reap zombie children

--- a/3.4/slim/Dockerfile
+++ b/3.4/slim/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
-ENV ALPINE_VERSION=3.5
+ENV ALPINE_VERSION=3.6
 
 # These are always installed. Notes:
 #   * dumb-init: a proper init system for containers, to reap zombie children

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
-ENV ALPINE_VERSION=3.5
+ENV ALPINE_VERSION=3.6
 
 # Install needed packages. Notes:
 #   * dumb-init: a proper init system for containers, to reap zombie children

--- a/latest/slim/Dockerfile
+++ b/latest/slim/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
-ENV ALPINE_VERSION=3.5
+ENV ALPINE_VERSION=3.6
 
 # These are always installed. Notes:
 #   * dumb-init: a proper init system for containers, to reap zombie children


### PR DESCRIPTION
This only updates all images to alpine 3.6
I've successfully run `build-all.sh` and all images was built fine.

```bash
Building jfloff/alpine-python:2.7: GOOD
Building jfloff/alpine-python:2.7-onbuild: GOOD
Building jfloff/alpine-python:2.7-slim: GOOD
Building jfloff/alpine-python:3.4: GOOD
Building jfloff/alpine-python:3.4-onbuild: GOOD
Building jfloff/alpine-python:3.4-slim: GOOD
Building jfloff/alpine-python:latest: GOOD
Building jfloff/alpine-python:latest-onbuild: GOOD
Building jfloff/alpine-python:latest-slim: GOOD
```
