### PR TITLE
add support for python3.7.2

### DIFF
--- a/3.7-onbuild/Dockerfile
+++ b/3.7-onbuild/Dockerfile
@@ -1,0 +1,99 @@
+FROM alpine:3.8
+
+# VERSIONS
+ENV ALPINE_VERSION=3.8 \
+    PYTHON_VERSION=3.7.2
+
+# PATHS
+ENV PYTHON_PATH=/usr/lib/python$PYTHON_VERSION \
+    PATH="/usr/lib/python$PYTHON_VERSION/bin/:${PATH}"
+
+# PACKAGES
+#   * dumb-init: a proper init system for containers, to reap zombie children
+#   * musl: standard C library
+#   * lib6-compat: compatibility libraries for glibc
+#   * linux-headers: commonly needed, and an unusual package name from Alpine.
+#   * build-base: used so we include the basic development packages (gcc)
+#   * bash: so we can access /bin/bash
+#   * git: to ease up clones of repos
+#   * ca-certificates: for SSL verification during Pip and easy_install
+ENV PACKAGES="\
+    dumb-init \
+    musl \
+    libc6-compat \
+    linux-headers \
+    build-base \
+    bash \
+    git \
+    ca-certificates \
+    libssl1.0 \
+    libffi-dev \
+"
+
+# PACKAGES needed to built python
+ENV PYTHON_BUILD_PACKAGES="\
+    readline-dev \
+    zlib-dev \
+    bzip2-dev \
+    sqlite-dev \
+    openssl-dev \
+"
+
+RUN set -ex ;\
+    # find MAJOR and MINOR python versions based on $PYTHON_VERSION
+    export PYTHON_MAJOR_VERSION=$(echo "${PYTHON_VERSION}" | rev | cut -d"." -f3-  | rev) ;\
+    export PYTHON_MINOR_VERSION=$(echo "${PYTHON_VERSION}" | rev | cut -d"." -f2-  | rev) ;\
+    # replacing default repositories with edge ones
+    echo "http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/community" >> /etc/apk/repositories ;\
+    echo "http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/main" >> /etc/apk/repositories ;\
+    # Add the packages, with a CDN-breakage fallback if needed
+    apk add --no-cache $PACKAGES || \
+        (sed -i -e 's/dl-cdn/dl-4/g' /etc/apk/repositories && apk add --no-cache $PACKAGES) ;\
+    # Add packages just for the python build process with a CDN-breakage fallback if needed
+    apk add --no-cache --virtual .build-deps $PYTHON_BUILD_PACKAGES || \
+        (sed -i -e 's/dl-cdn/dl-4/g' /etc/apk/repositories && apk add --no-cache --virtual .build-deps $PYTHON_BUILD_PACKAGES) ;\
+    # turn back the clock -- so hacky!
+    echo "http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/main/" > /etc/apk/repositories ;\
+    # echo "@community http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/community" >> /etc/apk/repositories ;\
+    # echo "@testing http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/testing" >> /etc/apk/repositories ;\
+    # echo "@edge-main http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories ;\
+    # use pyenv to download and compile specific python version
+    git clone --depth 1 https://github.com/pyenv/pyenv /usr/lib/pyenv ;\
+    PYENV_ROOT=/usr/lib/pyenv /usr/lib/pyenv/bin/pyenv install $PYTHON_VERSION ;\
+    # move specific version to correct path delete pyenv, no longer needed
+    mv /usr/lib/pyenv/versions/$PYTHON_VERSION/ $PYTHON_PATH ;\
+    rm -rfv /usr/lib/pyenv ;\
+    # change the path on the header of every file from PYENV_ROOT to PYTHON_PATH
+    cd $PYTHON_PATH/bin/ && sed -i "s+/usr/lib/pyenv/versions/$PYTHON_VERSION/+$PYTHON_PATH/+g" * ;\
+    # delete binary "duplicates" and replace them with symlinks
+    # this also optimizes space since they are actually the same binary
+    rm -f $PYTHON_PATH/bin/python$PYTHON_MAJOR_VERSION \
+          $PYTHON_PATH/bin/python$PYTHON_MINOR_VERSION \
+          $PYTHON_PATH/bin/python$PYTHON_MAJOR_VERSION-config \
+          $PYTHON_PATH/bin/python$PYTHON_MINOR_VERSION-config ;\
+    ln -sf $PYTHON_PATH/bin/python $PYTHON_PATH/bin/python$PYTHON_MAJOR_VERSION ;\
+    ln -sf $PYTHON_PATH/bin/python $PYTHON_PATH/bin/python$PYTHON_MINOR_VERSION ;\
+    ln -sf $PYTHON_PATH/bin/python-config $PYTHON_PATH/bin/python$PYTHON_MAJOR_VERSION-config ;\
+    ln -sf $PYTHON_PATH/bin/python-config $PYTHON_PATH/bin/python$PYTHON_MINOR_VERSION-config ;\
+    # delete files to to reduce container size
+    # tips taken from main python docker repo
+    find /usr/lib/python$PYTHON_VERSION -depth \( -name '*.pyo' -o -name '*.pyc' -o -name 'test' -o -name 'tests' \) -exec rm -rf '{}' + ;\
+    # remove build dependencies and any leftover apk cache
+    apk del --no-cache --purge .build-deps ;\
+    rm -rf /var/cache/apk/*
+
+# Copy in the entrypoint script -- this installs prerequisites on container start.
+COPY entrypoint.sh /entrypoint.sh
+
+# install requirements
+# this way when you build you won't need to install again
+# and since COPY is cached we don't need to wait
+ONBUILD COPY requirements.txt /tmp/requirements.txt
+
+# Run the dependencies installer and then allow it to be run again if needed.
+ONBUILD RUN /entrypoint.sh -r /tmp/requirements.txt
+ONBUILD RUN rm -f /requirements.installed
+
+# since we will be "always" mounting the volume, we can set this up
+ENTRYPOINT ["/usr/bin/dumb-init"]
+CMD ["python"]

--- a/3.7-onbuild/entrypoint.sh
+++ b/3.7-onbuild/entrypoint.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/dumb-init /bin/bash
+set -e
+
+APK_REQUIREMENTS=()
+BUILD_REQUIREMENTS=()
+PIP_REQUIREMENTS=()
+APKFILE='/apk-requirements.txt'
+BUILDFILE='/build-requirements.txt'
+REQFILE='/requirements.txt'
+VERBOSITY=1
+
+TMP_REQFILE='/tmp/requirements.txt'
+
+function usage () {
+	echo <<"EOF"
+Usage: $0 [-a -b -p -A -B -P -r -q -x] [--] <your command line>
+ -a : APK requirement. Can be specified multiple times.
+ -b : APK build requirement. These will be removed at the end to save space.
+ -p : Pip requirement. Can be specified multiple times.
+
+ -A : apk-requirements.txt file location,   default: /apk-requirements.txt
+ -B : build-requirements.txt file location, default: /build-requirements.txt
+ -P : requirements.txt file location,       default: /requirements.txt
+ -r : same as above, just to match Pip's -r flag.
+
+ -q : quiet, doesn't print anything at all.
+ -x : Bash debug mode. Extremely verbose!
+
+ -- : Separator for flags and your command
+
+ Whatever you provide after your arguments is run at the end.
+EOF
+  exit 1
+}
+
+function vlog () {
+	if [ $VERBOSITY -gt 0 ]; then
+		echo $1
+	fi
+}
+
+# Get and process arguments
+while getopts ":a:b:p:A:B:P:r:qx" opt; do
+  case $opt in
+    a) APK_REQUIREMENTS+=("$OPTARG") ;;
+    b) BUILD_REQUIREMENTS+=("$OPTARG") ;;
+    p) PIP_REQUIREMENTS+=("$OPTARG") ;;
+    A) APKFILE="$OPTARG" ;;
+    B) BUILDFILE="$OPTARG" ;;
+    P) REQFILE="$OPTARG" ;;
+		r) REQFILE="$OPTARG" ;;
+    q) VERBOSITY=0 ;;
+		x) set -x ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      usage
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      usage
+      ;;
+  esac
+done
+
+# Bad arguments
+if [ $? -ne 0 ];
+then
+  usage
+fi
+
+# Strip out all the arguments that have been processed
+shift $((OPTIND-1))
+
+# If there's a double dash at the end, get that off
+[[ $1 = "--" ]] && shift
+
+# Make some common flags objects
+PIP_FLAGS=''
+if [ $VERBOSITY -eq 0 ]; then
+	PIP_FLAGS="$PIP_FLAGS -q"
+fi
+
+APK_FLAGS='--no-cache --no-progress'
+if [ $VERBOSITY -eq 0 ]; then
+	APK_FLAGS="$APK_FLAGS -q"
+fi
+
+# Don't do anything if we've already done this.
+if [[ ! -f /requirements.installed ]]; then
+	vlog "First run, checking for any requirements..."
+
+  # Install any APK requirements
+  if [[ -f "$APKFILE" ]]; then
+		vlog "APK requirements file detected!"
+    APK_REQUIREMENTS+=($( cat "$APKFILE" ))
+  fi
+
+  if [[ -f "$BUILDFILE" ]]; then
+		vlog "Build requirements file detected!"
+    BUILD_REQUIREMENTS+=($( cat "$BUILDFILE" ))
+  fi
+
+  # Unfortunately the Alpine repositories are in a slightly inconsistent state for now-- python2 only exists in 'edge', not main.
+  # if [[ "$PYTHON_VERSION" == '2' ]]; then BUILD_PACKAGES="$(echo $BUILD_PACKAGES | sed -e 's/python2/python/g')"; fi \
+	vlog "Installing all APK requirements..."
+  apk add $APK_FLAGS $BUILD_PACKAGES "${APK_REQUIREMENTS[@]}" "${BUILD_REQUIREMENTS[@]}"
+
+  # Install any Pip requirements
+	if [[ -f "$REQFILE" && "$(cat $REQFILE | wc -l)" -gt 0 ]]; then
+		# Do this check a little early-- since we merge cli in with file,
+		# we'd get a false positive for logging otherwise.
+		vlog "Pip requirements file detected!"
+	fi
+
+	# If we use CLI parameters, we'll have to reassign this.
+	TARGET_REQFILE="$REQFILE"
+	if [[ ${#PIP_REQUIREMENTS[@]} -gt 0 ]]; then
+		# Put all Pip requirements into the same file.
+		printf "%s\n" "${PIP_REQUIREMENTS[@]}" >> "$TMP_REQFILE"
+
+		if [[ -f "$REQFILE" && "$(cat $REQFILE | wc -l)" -gt 0 ]]; then
+			cat "$REQFILE" >> "$TMP_REQFILE"
+		fi
+
+		TARGET_REQFILE="$TMP_REQFILE"
+	fi
+
+  if [[ -f $TARGET_REQFILE && "$(cat $TARGET_REQFILE | wc -l)" -gt 0 ]]; then
+		vlog "Upgrading Pip..."
+		pip install $PIP_FLAGS --upgrade pip
+		vlog "Installing all Pip requirements..."
+    pip install $PIP_FLAGS -r "$TARGET_REQFILE"
+  fi
+
+  # Remove packages that were only required for build.
+  apk del $APK_FLAGS $BUILD_PACKAGES "${BUILD_REQUIREMENTS[@]}"
+
+  touch /requirements.installed
+else
+	vlog "/requirements.installed file exists-- skipping requirements installs."
+fi
+
+
+if [[ ! -z "$@" ]]; then
+	# If the user has given us a command, run it.
+	$@
+else
+	# Otherwise, default to running 'python'.
+	python
+fi

--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -1,0 +1,87 @@
+FROM alpine:3.8
+
+# VERSIONS
+ENV ALPINE_VERSION=3.8 \
+    PYTHON_VERSION=3.7.2
+
+# PATHS
+ENV PYTHON_PATH=/usr/lib/python$PYTHON_VERSION \
+    PATH="/usr/lib/python$PYTHON_VERSION/bin/:${PATH}"
+
+# PACKAGES
+#   * dumb-init: a proper init system for containers, to reap zombie children
+#   * musl: standard C library
+#   * lib6-compat: compatibility libraries for glibc
+#   * linux-headers: commonly needed, and an unusual package name from Alpine.
+#   * build-base: used so we include the basic development packages (gcc)
+#   * bash: so we can access /bin/bash
+#   * git: to ease up clones of repos
+#   * ca-certificates: for SSL verification during Pip and easy_install
+ENV PACKAGES="\
+    dumb-init \
+    musl \
+    libc6-compat \
+    linux-headers \
+    build-base \
+    bash \
+    git \
+    ca-certificates \
+    libssl1.0 \
+    libffi-dev \
+"
+
+# PACKAGES needed to built python
+ENV PYTHON_BUILD_PACKAGES="\
+    readline-dev \
+    zlib-dev \
+    bzip2-dev \
+    sqlite-dev \
+    openssl-dev \
+"
+
+RUN set -ex ;\
+    # find MAJOR and MINOR python versions based on $PYTHON_VERSION
+    export PYTHON_MAJOR_VERSION=$(echo "${PYTHON_VERSION}" | rev | cut -d"." -f3-  | rev) ;\
+    export PYTHON_MINOR_VERSION=$(echo "${PYTHON_VERSION}" | rev | cut -d"." -f2-  | rev) ;\
+    # replacing default repositories with edge ones
+    echo "http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/community" >> /etc/apk/repositories ;\
+    echo "http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/main" >> /etc/apk/repositories ;\
+    # Add the packages, with a CDN-breakage fallback if needed
+    apk add --no-cache $PACKAGES || \
+        (sed -i -e 's/dl-cdn/dl-4/g' /etc/apk/repositories && apk add --no-cache $PACKAGES) ;\
+    # Add packages just for the python build process with a CDN-breakage fallback if needed
+    apk add --no-cache --virtual .build-deps $PYTHON_BUILD_PACKAGES || \
+        (sed -i -e 's/dl-cdn/dl-4/g' /etc/apk/repositories && apk add --no-cache --virtual .build-deps $PYTHON_BUILD_PACKAGES) ;\
+    # turn back the clock -- so hacky!
+    echo "http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/main/" > /etc/apk/repositories ;\
+    # echo "@community http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/community" >> /etc/apk/repositories ;\
+    # echo "@testing http://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/testing" >> /etc/apk/repositories ;\
+    # echo "@edge-main http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories ;\
+    # use pyenv to download and compile specific python version
+    git clone --depth 1 https://github.com/pyenv/pyenv /usr/lib/pyenv ;\
+    PYENV_ROOT=/usr/lib/pyenv /usr/lib/pyenv/bin/pyenv install $PYTHON_VERSION ;\
+    # move specific version to correct path delete pyenv, no longer needed
+    mv /usr/lib/pyenv/versions/$PYTHON_VERSION/ $PYTHON_PATH ;\
+    rm -rfv /usr/lib/pyenv ;\
+    # change the path on the header of every file from PYENV_ROOT to PYTHON_PATH
+    cd $PYTHON_PATH/bin/ && sed -i "s+/usr/lib/pyenv/versions/$PYTHON_VERSION/+$PYTHON_PATH/+g" * ;\
+    # delete binary "duplicates" and replace them with symlinks
+    # this also optimizes space since they are actually the same binary
+    rm -f $PYTHON_PATH/bin/python$PYTHON_MAJOR_VERSION \
+          $PYTHON_PATH/bin/python$PYTHON_MINOR_VERSION \
+          $PYTHON_PATH/bin/python$PYTHON_MAJOR_VERSION-config \
+          $PYTHON_PATH/bin/python$PYTHON_MINOR_VERSION-config ;\
+    ln -sf $PYTHON_PATH/bin/python $PYTHON_PATH/bin/python$PYTHON_MAJOR_VERSION ;\
+    ln -sf $PYTHON_PATH/bin/python $PYTHON_PATH/bin/python$PYTHON_MINOR_VERSION ;\
+    ln -sf $PYTHON_PATH/bin/python-config $PYTHON_PATH/bin/python$PYTHON_MAJOR_VERSION-config ;\
+    ln -sf $PYTHON_PATH/bin/python-config $PYTHON_PATH/bin/python$PYTHON_MINOR_VERSION-config ;\
+    # delete files to to reduce container size
+    # tips taken from main python docker repo
+    find /usr/lib/python$PYTHON_VERSION -depth \( -name '*.pyo' -o -name '*.pyc' -o -name 'test' -o -name 'tests' \) -exec rm -rf '{}' + ;\
+    # remove build dependencies and any leftover apk cache
+    apk del --no-cache --purge .build-deps ;\
+    rm -rf /var/cache/apk/*
+
+# since we will be "always" mounting the volume, we can set this up
+ENTRYPOINT ["/usr/bin/dumb-init"]
+CMD ["python"]


### PR DESCRIPTION
The only changes made from the 3.6.6 Dockerfiles is updating the `PYTHON_VERSION` environment variable and an additional package, `libffi-dev`, which was required for the python build to complete.
