### PR TITLE
Fix usage text output

### DIFF
--- a/2.7-onbuild/entrypoint.sh
+++ b/2.7-onbuild/entrypoint.sh
@@ -12,7 +12,7 @@ VERBOSITY=1
 TMP_REQFILE='/tmp/requirements.txt'
 
 function usage () {
-	echo <<"EOF"
+	cat <<"EOF"
 Usage: $0 [-a -b -p -A -B -P -r -q -x] [--] <your command line>
  -a : APK requirement. Can be specified multiple times.
  -b : APK build requirement. These will be removed at the end to save space.

--- a/2.7-slim/entrypoint.sh
+++ b/2.7-slim/entrypoint.sh
@@ -12,7 +12,7 @@ VERBOSITY=1
 TMP_REQFILE='/tmp/requirements.txt'
 
 function usage () {
-	echo <<"EOF"
+	cat <<"EOF"
 Usage: $0 [-a -b -p -A -B -P -r -q -x] [--] <your command line>
  -a : APK requirement. Can be specified multiple times.
  -b : APK build requirement. These will be removed at the end to save space.

--- a/3.6-onbuild/entrypoint.sh
+++ b/3.6-onbuild/entrypoint.sh
@@ -12,7 +12,7 @@ VERBOSITY=1
 TMP_REQFILE='/tmp/requirements.txt'
 
 function usage () {
-	echo <<"EOF"
+	cat <<"EOF"
 Usage: $0 [-a -b -p -A -B -P -r -q -x] [--] <your command line>
  -a : APK requirement. Can be specified multiple times.
  -b : APK build requirement. These will be removed at the end to save space.

--- a/3.6-slim/entrypoint.sh
+++ b/3.6-slim/entrypoint.sh
@@ -12,7 +12,7 @@ VERBOSITY=1
 TMP_REQFILE='/tmp/requirements.txt'
 
 function usage () {
-	echo <<"EOF"
+	cat <<"EOF"
 Usage: $0 [-a -b -p -A -B -P -r -q -x] [--] <your command line>
  -a : APK requirement. Can be specified multiple times.
  -b : APK build requirement. These will be removed at the end to save space.

--- a/3.7-onbuild/entrypoint.sh
+++ b/3.7-onbuild/entrypoint.sh
@@ -12,7 +12,7 @@ VERBOSITY=1
 TMP_REQFILE='/tmp/requirements.txt'
 
 function usage () {
-	echo <<"EOF"
+	cat <<"EOF"
 Usage: $0 [-a -b -p -A -B -P -r -q -x] [--] <your command line>
  -a : APK requirement. Can be specified multiple times.
  -b : APK build requirement. These will be removed at the end to save space.

--- a/3.7-slim/entrypoint.sh
+++ b/3.7-slim/entrypoint.sh
@@ -12,7 +12,7 @@ VERBOSITY=1
 TMP_REQFILE='/tmp/requirements.txt'
 
 function usage () {
-	echo <<"EOF"
+	cat <<"EOF"
 Usage: $0 [-a -b -p -A -B -P -r -q -x] [--] <your command line>
  -a : APK requirement. Can be specified multiple times.
  -b : APK build requirement. These will be removed at the end to save space.


### PR DESCRIPTION
This PR fixes the issue that the usage text is never printed to the console if invalid arguments were passed to the `entrypoint.sh` script.

The culprit is that the `usage` function uses the `<<EOF` construct with the `echo` command while the proper command to use with this construct is `cat`.

Closes #62