### PR TITLE
failed when tried to fetch python binary

### DIFF
--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -28,6 +28,7 @@ ENV PYTHON_PATH=/usr/local/bin/ \
       libressl-dev \
       libffi-dev \
       tzdata \
+      wget \
     " \
     # PACKAGES needed to built python
     PYTHON_BUILD_PACKAGES="\


### PR DESCRIPTION
`pyenv install -v $PYTHON_VERSION`

The above line failed with error: 

Downloading Python-3.7.3.tar.xz...
-> https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz
error: failed to download Python-3.7.3.tar.gz

After I added the wget to the package list, it's OK